### PR TITLE
Typo: '<tr>' should have been '<td>'

### DIFF
--- a/docs/v3/guide/lists.md
+++ b/docs/v3/guide/lists.md
@@ -100,7 +100,7 @@ const table = list("table", Tr);
 mount(document.body, table);
 ```
 
-This works, but in case you need to access `this.el.el` (`<tr>`) in `Tr`, I recommend to use the following:
+This works, but in case you need to access `this.el.el` (`<td>`) in `Tr`, I recommend to use the following:
 
 ```js
 class Td {


### PR DESCRIPTION
`this.el.el` is the `<td>` element and not `<tr>`.