### PR TITLE
fix: fix link to benchmarks

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -104,7 +104,7 @@ export default class Home {
                                 target: "_blank",
                                 title: "Benchmark",
                                 href:
-                                    "https://rawgit.com/krausest/js-framework-benchmark/master/webdriver-ts-results/table.html",
+                                    "https://krausest.github.io/js-framework-benchmark/2024/table_chrome_121.0.6167.85.html",
                                 rel: "noopener",
                             },
                             "(benchmark)"


### PR DESCRIPTION
This PR fixes the link to the benchmarks, rawgit does not exist anymore so this points to the latest table on `js-framework-benchmark` GitHub Pages site. 

https://krausest.github.io/js-framework-benchmark/2024/table_chrome_121.0.6167.85.html

There's no "latest" table, so one cannot just link to that.